### PR TITLE
Improve degree sign

### DIFF
--- a/documentation/documentation-sources/xits-specimen.tex
+++ b/documentation/documentation-sources/xits-specimen.tex
@@ -70,11 +70,11 @@ x = {-b \pm \sqrt{b^2 - 4ac} \over 2a}
 \stopformula
 
 \startformula
-\sin 18^\circ = {1\over 4} (\sqrt{5}-1)
+\sin 18\textdegree = {1\over 4} (\sqrt{5}-1)
 \stopformula
 
 \startformula
-k=1.38 \times 10^{-16}\,\rm erg/^\circ K
+k=1.38 \times 10^{-16}\,\rm erg/\textdegree K
 \stopformula
 
 \startformula


### PR DESCRIPTION
This change using true degree sign rather than superscript circle to get better appearance. 
See: https://en.wikipedia.org/wiki/Degree_symbol